### PR TITLE
fix cron format

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -25,7 +25,7 @@ sudo apachectl -k restart
 #write out current crontab
 crontab -l > mycron
 #echo new cron into cron file
-echo "0 0 * * * * echo 'syncing server.php' && php /var/www/html server.php" >> mycron
+echo "0 0 * * * echo 'syncing server.php' && php /var/www/html server.php" >> mycron
 #install new cron file
 crontab mycron
 rm mycron


### PR DESCRIPTION
Cron job was in the wrong format for GCP and the periodic update was failing with `startup-script: "mycron":0: bad command`