### PR TITLE
Dockerise the build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 node_modules
 Dockerfile
+.git
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .DS_Store
 data
 .env
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
 FROM debian:buster-slim
-ADD . .
 # Install Git, PHP, Node and NPM
 WORKDIR /var/www
-RUN apt-get update && apt-get install -y git apache2 php libapache2-mod-php php-curl curl nodejs npm
-# Get the application source code
-RUN rm -rf /var/www/html && git clone https://github.com/co2widget/cambridgezero-widget.git /var/www/html
+RUN apt-get update && apt-get install -y git cron apache2 php libapache2-mod-php php-curl curl nodejs npm
+RUN rm -rf /var/www/html && mkdir /var/www/html
 WORKDIR /var/www/html
-# for now limiting branch to this known one...
-RUN git checkout 2af00077fa422c2aa46cff4c48bd15e5ff3bd0f5
-# Get nvm etc
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+# Add the application source code
+ADD . .
+# Build
 RUN npm i && npm rebuild node-sass
 ARG URL
 ENV URL ${URL:-co2widget.com}
-RUN node_modules/.bin/gulp && chmod 777 /var/www/html/build && php server.php
-RUN apt-get install -y cron
+RUN chmod 777 /var/www/html/build && php server.php && node_modules/.bin/gulp
 
-ENTRYPOINT echo "* * * * * echo 'syncing server.php' && php /var/www/html/server.php && npm run build && apachectl -k restart" >> mycron ; \
-    crontab mycron
+EXPOSE 80
+ENTRYPOINT service cron start && echo URL=$URL && \
+    echo "0 0,6,12,18 * * * (cd /var/www/html && echo 'syncing server.php'  && php /var/www/html/server.php && npm run build) >/proc/1/fd/1 2>&1" >> mycron ; \
+    crontab mycron ;  php /var/www/html/server.php ; apachectl -k restart ; sleep infinity

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN chmod 777 /var/www/html/build && php server.php && node_modules/.bin/gulp
 EXPOSE 80
 ENTRYPOINT service cron start && echo URL=$URL && \
     echo "0 0,6,12,18 * * * (cd /var/www/html && echo 'syncing server.php'  && php /var/www/html/server.php && npm run build) >/proc/1/fd/1 2>&1" >> mycron ; \
-    crontab mycron ;  php /var/www/html/server.php ; apachectl -k restart ; sleep infinity
+    crontab mycron ; php /var/www/html/server.php && npm run build ; apachectl -k restart ; sleep infinity

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN git checkout 2af00077fa422c2aa46cff4c48bd15e5ff3bd0f5
 # Get nvm etc
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 ENV NVM_DIR "/root/.nvm"
-RUN . "$NVM_DIR/nvm.sh" && nvm install 12.18.2 && cd /var/www/html && npm i && npm rebuild node-sass
+RUN . /root/nvm.sh && nvm install 12.18.2 && cd /var/www/html && npm i && npm rebuild node-sass
 ARG URL
 RUN node_modules/.bin/gulp && chmod 777 /var/www/html/build && php server.php
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:buster-slim
+ADD . .
+RUN apt-get update
+# Install Git, PHP, Node and NPM
+RUN apt-get install -y apache2 php libapache2-mod-php php-curl curl git
+# Get the application source code
+RUN rm -rf /var/www/html && mkdir /var/www/html && chmod 777 /var/www/html
+RUN git clone https://github.com/co2widget/cambridgezero-widget.git /var/www/html
+# for now limiting branch to this known one...
+RUN git checkout 2af00077fa422c2aa46cff4c48bd15e5ff3bd0f5
+# Get nvm etc
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+ENV NVM_DIR "/root/.nvm"
+RUN . "$NVM_DIR/nvm.sh" && nvm install 12.18.2 && cd /var/www/html && npm i && npm rebuild node-sass
+ARG URL
+RUN node_modules/.bin/gulp && chmod 777 /var/www/html/build && php server.php
+
+ENTRYPOINT echo "0 0,6,12,18 * * * echo 'syncing server.php' && php /var/www/html/server.php && npm run build && apachectl -k restart" >> mycron ; \
+    crontab mycron

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
 FROM debian:buster-slim
 ADD . .
-RUN apt-get update
 # Install Git, PHP, Node and NPM
-RUN apt-get install -y apache2 php libapache2-mod-php php-curl curl git
+WORKDIR /var/www
+RUN apt-get update && apt-get install -y git apache2 php libapache2-mod-php php-curl curl nodejs npm
 # Get the application source code
-RUN rm -rf /var/www/html && mkdir /var/www/html && chmod 777 /var/www/html
-RUN git clone https://github.com/co2widget/cambridgezero-widget.git /var/www/html
+RUN rm -rf /var/www/html && git clone https://github.com/co2widget/cambridgezero-widget.git /var/www/html
+WORKDIR /var/www/html
 # for now limiting branch to this known one...
 RUN git checkout 2af00077fa422c2aa46cff4c48bd15e5ff3bd0f5
 # Get nvm etc
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-ENV NVM_DIR "/root/.nvm"
-RUN . /root/nvm.sh && nvm install 12.18.2 && cd /var/www/html && npm i && npm rebuild node-sass
+RUN npm i && npm rebuild node-sass
 ARG URL
+ENV URL ${URL:-co2widget.com}
 RUN node_modules/.bin/gulp && chmod 777 /var/www/html/build && php server.php
+RUN apt-get install -y cron
 
-ENTRYPOINT echo "0 0,6,12,18 * * * echo 'syncing server.php' && php /var/www/html/server.php && npm run build && apachectl -k restart" >> mycron ; \
+ENTRYPOINT echo "* * * * * echo 'syncing server.php' && php /var/www/html/server.php && npm run build && apachectl -k restart" >> mycron ; \
     crontab mycron

--- a/make.sh
+++ b/make.sh
@@ -10,18 +10,12 @@ apt-get install -y curl git
 rm -rf /var/www/html
 mkdir /var/www/html
 chmod 777 /var/www/html
-git clone https://github.com/co2widget/cambridgezero-widget.git /var/www/html
-git checkout 2af00077fa422c2aa46cff4c48bd15e5ff3bd0f5
+git clone -b gc-deployment https://{user}:{auth}@github.com/ChrisButterworth/cambridgezero-widget.git /var/www/html
 
 # Run NPM
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-nvm install 12.18.2
-nvm use 12.18.2
+apt-get install -y nodejs npm
 cd /var/www/html
 npm i
-npm rebuild node-sass
 URL=co2widget.com node_modules/.bin/gulp
 chmod 777 /var/www/html/build
 php server.php
@@ -31,7 +25,7 @@ sudo apachectl -k restart
 #write out current crontab
 crontab -l > mycron
 #echo new cron into cron file
-echo "0 0,6,12,18 * * * echo 'syncing server.php' && php /var/www/html/server.php && npm run build && apachectl -k restart" >> mycron
+echo "0 0 * * * echo 'syncing server.php' && php /var/www/html server.php" >> mycron
 #install new cron file
 crontab mycron
 rm mycron

--- a/make.sh
+++ b/make.sh
@@ -10,12 +10,18 @@ apt-get install -y curl git
 rm -rf /var/www/html
 mkdir /var/www/html
 chmod 777 /var/www/html
-git clone -b gc-deployment https://{user}:{auth}@github.com/ChrisButterworth/cambridgezero-widget.git /var/www/html
+git clone https://github.com/co2widget/cambridgezero-widget.git /var/www/html
+git checkout 2af00077fa422c2aa46cff4c48bd15e5ff3bd0f5
 
 # Run NPM
-apt-get install -y nodejs npm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+nvm install 12.18.2
+nvm use 12.18.2
 cd /var/www/html
 npm i
+npm rebuild node-sass
 URL=co2widget.com node_modules/.bin/gulp
 chmod 777 /var/www/html/build
 php server.php
@@ -25,7 +31,7 @@ sudo apachectl -k restart
 #write out current crontab
 crontab -l > mycron
 #echo new cron into cron file
-echo "0 0 * * * echo 'syncing server.php' && php /var/www/html server.php" >> mycron
+echo "0 0,6,12,18 * * * echo 'syncing server.php' && php /var/www/html/server.php && apachectl -k restart" >> mycron
 #install new cron file
 crontab mycron
 rm mycron

--- a/make.sh
+++ b/make.sh
@@ -31,7 +31,7 @@ sudo apachectl -k restart
 #write out current crontab
 crontab -l > mycron
 #echo new cron into cron file
-echo "0 0,6,12,18 * * * echo 'syncing server.php' && php /var/www/html/server.php && apachectl -k restart" >> mycron
+echo "0 0,6,12,18 * * * echo 'syncing server.php' && php /var/www/html/server.php && npm run build && apachectl -k restart" >> mycron
 #install new cron file
 crontab mycron
 rm mycron

--- a/server/import.php
+++ b/server/import.php
@@ -39,6 +39,7 @@ class Import {
 			'year' => date('Y'), // Current year to get halfway point easier on chart
 			'date' => date('j M Y'), // Current year to get halfway point easier on chart
 			'angle' => Import::angle($change),
+			'buildTime' => date(DATE_RSS),
 		]);
 
 		//print_r($data);


### PR DESCRIPTION
- Hugely reduces startup time on GCP, and makes it a lot easier to test and debug the build
- Also added a 'buildTime' field to the php output, to make it easier to verify that the cronjob is working as expected
- The site is now using the `cambridge-zero-widget-dockerised` template, which is based on this branch. Code changes should be a lot easier to deploy with this configuration, since it's now just a case of building and tagging a new docker image, and pushing it up to the repository.